### PR TITLE
fix: post cors issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,12 +5,15 @@ import {
 } from './router/post.js'
 // Controller
 import { getPost, createPost } from './controller/post.js'
-import { errorHandle } from './utils/resHandle.js'
+import { errorHandle, headers } from './utils/resHandle.js'
 
 const app = async (req, res) => {
   if (await getPostUrl(req)) getPost(req, res)
   else if (await createPostUrl(req)) createPost(req, res)
-  else errorHandle({ res })
+  else if (req.method === 'OPTIONS') {
+    res.writeHead(200, headers)
+    res.end()
+  } else errorHandle({ res })
 }
 
 export default app

--- a/utils/resHandle.js
+++ b/utils/resHandle.js
@@ -2,7 +2,8 @@ const headers = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Headers': 'Content-Type, Authorization, Content-Length, X-Requested-With, Accept',
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Methods': 'GET POST OPTIONS DELETE PATCH',
+  'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, DELETE, PATCH',
+  'Access-Control-Allow-Credentials': true,
 }
 
 const successHandle = ({
@@ -38,4 +39,5 @@ const errorHandle = ({
 export {
   successHandle,
   errorHandle,
+  headers,
 }


### PR DESCRIPTION
(小麥)

## 問題
在測試 post 方法是會有 cors 問題
應該是帶了 Authorization header 的請求，變成非簡單請求
需要處理預請求的狀況

```js
fetch('http://localhost:3005/posts', {
    headers: { Authorization: '123' },
    method: 'POST',
    body: JSON.stringify({ userName: '小叮噹', userContent: '我的耳朵呢QQ' })
}).then(res => res.json()).then(data=>console.log(data))
```

## 解決
1. 處理 method = OPTIONS 的回傳，讓預請求成功
2. headers 中的 Access-Control-Allow-Methods，要用逗號分隔開來