### PR TITLE
fix: cross-env not installed on heroku

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "cors": "^2.8.5",
+    "cross-env": "^7.0.3",
     "dotenv": "^16.0.0",
     "express": "^4.18.1",
     "mongoose": "^6.3.0",
@@ -31,7 +32,6 @@
   },
   "homepage": "https://github.com/ayugioh2003/metawallBackend#readme",
   "devDependencies": {
-    "cross-env": "^7.0.3",
     "eslint": "^8.13.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.26.0",


### PR DESCRIPTION
feature/express 合併後，heroku 網站就掛掉了
開 heroku logs --tail 看錯誤訊息
看到
```bash
2022-05-03T08:52:44.169178+00:00 app[web.1]: > metawallbackend@1.0.0 start /app
2022-05-03T08:52:44.169178+00:00 app[web.1]: > cross-env NODE_ENV=production node server.js
2022-05-03T08:52:44.169179+00:00 app[web.1]:
2022-05-03T08:52:44.177240+00:00 app[web.1]: sh: 1: cross-env: not found
```
懷疑是 cross-env 的問題

網路資料說，heroku 只會安裝 dependencies 裡面的套件，會忽略 dev 的
所以我手動把 cross-env 從 dev 裡面拿出來
- https://github.com/diegohaz/arc/issues/269
- https://stackoverflow.com/questions/68676394/sh-1-cross-env-not-in-node-js-app-found-while-deploying-to-heroku