### PR TITLE
fix(Model): 修復 Model 設定 createdAt, updatedAt 不會自動更新時間

### DIFF
--- a/model/image.js
+++ b/model/image.js
@@ -10,18 +10,22 @@ const ImageSchema = new mongoose.Schema({
     type: String,
     required: [true, '圖片網址為必填']
   },
+
   // 建立時間，轉為 Timestamp 以方便前端好處理
   createdAt: {
     type: Number,
-    default: new Date().getTime(),
   },
 
   // 更新時間，轉為 Timestamp 以方便前端好處理
   updatedAt: {
     type: Number,
-    default: new Date().getTime(),
   },
-}, { versionKey: false })
+}, {
+  versionKey: false,
+  timestamps: {
+    currentTime: () => Date.now()
+  }
+})
 
 const Image = mongoose.model('Image', ImageSchema)
 module.exports = Image

--- a/model/post.js
+++ b/model/post.js
@@ -22,16 +22,19 @@ const PostSchema = new mongoose.Schema(
     // 建立時間，轉為 Timestamp 以方便前端好處理
     createdAt: {
       type: Number,
-      default: new Date().getTime(),
     },
 
     // 更新時間，轉為 Timestamp 以方便前端好處理
     updatedAt: {
       type: Number,
-      default: new Date().getTime(),
     },
   },
-  { versionKey: false },
+  {
+    versionKey: false,
+    timestamps: {
+      currentTime: () => Date.now()
+    }
+  },
 )
 
 const Post = mongoose.model('Post', PostSchema)

--- a/model/user.js
+++ b/model/user.js
@@ -51,16 +51,19 @@ const UserSchema = new mongoose.Schema({
   // 建立時間，轉為 Timestamp 以方便前端好處理
   createdAt: {
     type: Number,
-    default: new Date().getTime(),
   },
 
   // 更新時間，轉為 Timestamp 以方便前端好處理
   updatedAt: {
     type: Number,
-    default: new Date().getTime(),
   },
 },
-  { versionKey: false }
+  {
+    versionKey: false,
+    timestamps: {
+      currentTime: () => Date.now()
+    }
+  }
 )
 
 


### PR DESCRIPTION
@ayugioh2003 這幾天測試到一個問題，凡是有用到建立資料、欄位有 createdAt, updatedAt ，像是建立使用者（打註冊 API：api/auth/signup），即使在不同時間建立，createdAt, updatedAt 時間都會一致，沒有變動。

打兩隻註冊 API (api/auth/signup)，中間間隔2-4秒，並成功建立兩位 User 資料
- 預期結果：第一位 User 的 createdAt 與 第二位 User 的 createdAt 時間應要不同，差幾秒
- 實際結果：第一位 User 與 第二位 User 的 createdAt, updatedAt 數字相同

由於是我闖的鍋，當初沒仔細檢查這塊，我補了一個 commit 修復這個問題，再麻煩小麥看看，不好意思