### PR TITLE
fix(auth): _id 欄位打成 id

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -206,7 +206,7 @@ const checkToken = catchAsync(async (req, res, next) => {
   const verify = await verifyToken(token)
   console.log('verify', verify)
   if (verify) {
-    const result = await User.findOne({ id: verify }, '_id name email')
+    const result = await User.findOne({ _id: verify }, '_id name email')
     console.log(result)
     return successHandle({ res, message: '驗證通過', data: result })
   }
@@ -244,7 +244,7 @@ const isAuth = async (req, res, next) => {
   const verify = await verifyToken(token)
   if (verify) {
     console.log('驗證通過')
-    const result = await User.findOne({ id: verify }, '_id name email')
+    const result = await User.findOne({ _id: verify }, '_id name email')
     req.user = result
     next()
   } else {


### PR DESCRIPTION
(小麥)

感謝 Nap 幫忙抓 bug
auth middleware 從 token 抓到 id 資訊後，會去 users 資料表撈資料
原先寫法是 ` const result = await User.findOne({ id: verify }, '_id name email')`
但應該要是 ` const result = await User.findOne({ _id: verify }, '_id name email')`
要用 _id 去找
不然使用者資料會一直找到第一筆

請 Nap 幫忙查看與審核一下 code ~
OK 的話就幫忙 merge 回 main 分支