### PR TITLE
fix(eslint): eslint config

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -21,6 +21,8 @@ module.exports = {
     'no-console': ['error', { allow: ['warn', 'error'] }],
     quotes: ['error', 'single'], // 單引號
     indent: ['error', 2], // 縮排
-    'no-multiple-empty-lines': ['error'], // 允許最大連續斷一行
+    'no-multiple-empty-lines': ['error'], // 允許最大連續斷一行,
+    'linebreak-style': ['error', 'windows'],
+    'no-param-reassign': [2, { props: false }],
   },
 }

--- a/controller/globalError.js
+++ b/controller/globalError.js
@@ -1,4 +1,4 @@
-const ApiState = require('../utils/apiState')
+const ApiState = require('../utils/apiState.js')
 
 // DB 欄位驗證
 const handleValidationErrorDB = (err) => {
@@ -47,14 +47,14 @@ module.exports = (err, req, res, next) => {
 
   err.statusCode = err.statusCode ?? customeMessage.statusCode
   err.status = err.status ?? customeMessage.status
-  err.name = err.name
-  err.stack = err.stack
+  // err.name = err.name
+  // err.stack = err.stack
   console.log('err.status', err.status)
 
   if (err instanceof SyntaxError) setError(ApiState.SYNTAX_ERROR, err)
   if (err instanceof ReferenceError) setError(ApiState.REFERENCE_ERROR, err)
   if (err instanceof TypeError) setError(ApiState.TYPE_ERROR, err)
-  if (err.name === 'ValidationError') error = handleValidationErrorDB(err)
+  if (err.name === 'ValidationError') handleValidationErrorDB(err)
   else {
     err.message = isDev
       ? err.message


### PR DESCRIPTION
(小麥)

修改兩個 eslint 設定

```js
{
    'linebreak-style': ['error', 'windows'], // LF CRLF 換行符號問題
    'no-param-reassign': [2, { props: false }], // req.body, err.name 重新賦值問題
}
```

console.log 的 unexpected console statement 的 eslint 錯誤留著
因為程式中的 console.log 本來就越少越好

isDev() && sendErrorDev(err, res) 的 Expected an assignment or function call and instead saw an expression 也留著
因為這種寫法雖然 work，但不適合常常用到

相關 Issue
https://github.com/ayugioh2003/metawallBackend/issues/27