### PR TITLE
fix(Auth): isAuth

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -1,18 +1,21 @@
+/* eslint-disable consistent-return */
+/* eslint-disable prefer-destructuring */
+/* eslint-disable no-underscore-dangle */
 // Model
 const jwt = require('jsonwebtoken')
-const User = require('../model/user')
+const User = require('../model/user.js')
 // Utils
-const catchAsync = require('../utils/catchAsync')
-const AppError = require('../utils/appError')
-const ApiState = require('../utils/apiState')
+const catchAsync = require('../utils/catchAsync.js')
+const AppError = require('../utils/appError.js')
+const ApiState = require('../utils/apiState.js')
 const { successHandle } = require('../utils/resHandle.js')
 
 const {
   checkEmail,
   checkPassword,
   verifyToken,
-} = require('../utils/verification')
-const { hashPassword } = require('../utils/hash')
+} = require('../utils/verification.js')
+const { hashPassword } = require('../utils/hash.js')
 // jwt
 
 /*
@@ -23,7 +26,7 @@ const { hashPassword } = require('../utils/hash')
 */
 
 /*
-  登入功能	POST	/login
+  登入功能 POST /login
 */
 const login = catchAsync(async (req, res, next) => {
   const memberData = {
@@ -46,8 +49,6 @@ const login = catchAsync(async (req, res, next) => {
     email: memberData.email,
     password: memberData.password,
   }).exec((findErr, findRes) => {
-    console.log('findErr', findErr)
-    console.log('findRes', findRes)
     if (findErr) {
       return next(
         new AppError({
@@ -97,7 +98,7 @@ const login = catchAsync(async (req, res, next) => {
 })
 
 /*
-  註冊功能	POST	/signup
+  註冊功能 POST /signup
 */
 const signup = catchAsync(async (req, res, next) => {
   const memberData = {
@@ -132,8 +133,6 @@ const signup = catchAsync(async (req, res, next) => {
 
   User.findOne({ email: memberData.email }, '_id name email').exec(
     (findErr, findRes) => {
-      console.log('findErr', findErr)
-      console.log('findRes', findRes)
       if (findErr) {
         return next(
           new AppError({
@@ -156,7 +155,6 @@ const signup = catchAsync(async (req, res, next) => {
 
   memberData.password = hashPassword(req.body.password)
   const createRes = await User.create(memberData)
-  console.log('createRes', createRes)
   const data = {
     _id: createRes._id,
     name: createRes.name,
@@ -204,13 +202,11 @@ const checkToken = catchAsync(async (req, res, next) => {
 
   // 取的token驗證通過解密出來的使用者id
   const verify = await verifyToken(token)
-  console.log('verify', verify)
   if (verify) {
     const result = await User.findOne({ _id: verify }, '_id name email')
-    console.log(result)
     return successHandle({ res, message: '驗證通過', data: result })
   }
-  console.log('ApiState.FAIL.status', ApiState.FAIL.status)
+
   return next(
     new AppError({
       message: 'token不符合',
@@ -243,7 +239,6 @@ const isAuth = async (req, res, next) => {
   // 取的token驗證通過解密出來的使用者id
   const verify = await verifyToken(token)
   if (verify) {
-    console.log('驗證通過')
     const result = await User.findOne({ _id: verify }, '_id name email')
     req.user = result
     next()

--- a/controller/auth.js
+++ b/controller/auth.js
@@ -236,10 +236,12 @@ const isAuth = async (req, res, next) => {
       }),
     )
   }
-  // 取的token驗證通過解密出來的使用者id
+  // 取得 token 驗證通過解密出來的使用者id
   const verify = await verifyToken(token)
   if (verify) {
     const result = await User.findOne({ _id: verify }, '_id name email')
+    if (!result) return next(new AppError(ApiState.LOGIN_FAILED))
+
     req.user = result
     next()
   } else {


### PR DESCRIPTION
### 針對 authController.isAuth function 發現 Bug
用Token找不到 User時，仍通過 isAuth，造成需要登入才能執行的 API 出現 Type Error 錯誤
- 預期結果：Token過期或找不到User，應直接回傳登入失敗的訊息
- 實際結果：回傳 5003 Type Error，型態錯誤


**觸發 Bug 流程**
1. Postman 設定 [POST] 新增貼文 /api/posts，headers 設定環境變數
2. Postman 登入API，設定 scripts，將 token 設定環境變數 accessToken
3. 昨晚請求登入後，回傳的 Token 存在 Postman 環境變數 accessToken
4. 今日請求打新增貼文，會直接報錯（因 accessToken 是昨日登入取得的，還是舊的）
```javascript
{
    "status": 5003,
    "message": "Type Error，型態錯誤",
    "stack": "TypeError: Type Error，型態錯誤\n    ....省略"
}
```

**原因**
- `const result = await User.findOne({ _id: verify }, '_id name email')，這裡的 result 沒有值，導致 req.user = 空

```javascript
// 取得 token 驗證通過解密出來的使用者id
  const verify = await verifyToken(token)
  if (verify) {
    const result = await User.findOne({ _id: verify }, '_id name email')
    req.user = result
    next()
  } else {
    return next(
      new AppError({
        message: ApiState.LOGIN_FAILED.message,
        status: ApiState.LOGIN_FAILED.status,
        statusCode: ApiState.LOGIN_FAILED.statusCode,
      }),
    )
  }
```

https://imgur.com/a/TkkHqHQ


