### PR TITLE
使用者修改密碼從 auth 模組 轉移到 users 模組

### DIFF
--- a/controller/auth.js
+++ b/controller/auth.js
@@ -171,49 +171,6 @@ const logout = catchAsync(async (req, res, next) => {
 })
 
 /*
-  修改密碼 PATCH /reset-password
-*/
-const resetPassword = catchAsync(async (req, res, next) => {
-  const user = req.user
-  const { password, confirmPassword } = req.body
-  if (!password || !confirmPassword) {
-    return next(
-      new AppError({
-        statusCode: ApiState.FIELD_MISSING.statusCode,
-        status: ApiState.FIELD_MISSING.status,
-        message: '新密碼及再次確認新密碼為必填項目',
-      }),
-    )
-  }
-  if (!checkPassword(req.body.password)) {
-    return next(
-      new AppError({
-        statusCode: ApiState.FIELD_MISSING.statusCode,
-        status: ApiState.FIELD_MISSING.status,
-        message: '密碼格式錯誤，需包含至少一個英文字與數字，密碼八碼以上',
-      }),
-    )
-  }
-  if (password !== confirmPassword) {
-    return next(
-      new AppError({
-        statusCode: ApiState.FAIL.statusCode,
-        status: ApiState.FAIL.status,
-        message: '新密碼及再次確認新密碼不一致',
-      }),
-    )
-  }
-  const newPassword = hashPassword(password)
-  const editUser = await User.findByIdAndUpdate(user?.id, { password: newPassword }, { returnDocument: 'after', runValidators: true })
-  if (!editUser) {
-    return next(
-      new AppError(ApiState.UPDATE_FAILED),
-    )
-  }
-  successHandle({ res, message: '修改密碼成功', data: editUser })
-})
-
-/*
   驗證token GET /check
 */
 const checkToken = catchAsync(async (req, res, next) => {
@@ -295,7 +252,7 @@ module.exports = {
   login,
   signup,
   logout,
-  resetPassword,
   checkToken,
   isAuth,
+  checkPassword,
 }

--- a/controller/user.js
+++ b/controller/user.js
@@ -28,16 +28,18 @@ const updateCurrentUserInfo = catchAsync(async (req, res, next) => {
   avatar = avatar?.trim()
   const editData = {}
   // 暱稱必填
-  if (!name || name?.length < 2) {
+  if (name !== undefined && (!name || name?.length < 2)) {
     return next(new AppError({
       statusCode: ApiState.FIELD_MISSING.statusCode,
       status: ApiState.FIELD_MISSING.status,
       message: '暱稱為必填，且至少為兩字元',
     }))
   }
-  editData.name = name
+  if (name !== undefined) {
+    editData.name = name
+  }
   // 性別
-  if (gender) {
+  if (gender !== undefined) {
     const sex = ['male', 'female']
     if (!sex.some((item) => item === gender)) {
       return next(new AppError({
@@ -49,7 +51,7 @@ const updateCurrentUserInfo = catchAsync(async (req, res, next) => {
     editData.gender = gender
   }
   // 頭像
-  if (avatar) {
+  if (avatar !== undefined) {
     editData.avatar = avatar
   }
   const editUser = await User.findByIdAndUpdate(user?.id, editData, { returnDocument: 'after', runValidators: true })
@@ -99,16 +101,18 @@ const updateUserInfo = catchAsync(async (req, res, next) => {
     return next(new AppError(ApiState.ROUTER_NOT_FOUND))
   }
   // 暱稱必填
-  if (!name || name?.toString()?.length < 2) {
+  if (name !== undefined && (!name || name?.toString()?.length < 2)) {
     return next(new AppError({
       statusCode: ApiState.FIELD_MISSING.statusCode,
       status: ApiState.FIELD_MISSING.status,
       message: '暱稱為必填，且至少為兩字元',
     }))
   }
-  editData.name = name
+  if (name !== undefined) {
+    editData.name = name
+  }
   // 性別
-  if (gender) {
+  if (gender !== undefined) {
     const sex = ['male', 'female']
     if (!sex.some((item) => item === gender)) {
       return next(new AppError({
@@ -120,7 +124,7 @@ const updateUserInfo = catchAsync(async (req, res, next) => {
     editData.gender = gender
   }
   // 頭像
-  if (avatar) {
+  if (avatar !== undefined) {
     editData.avatar = avatar
   }
   const editUser = await User.findByIdAndUpdate(userId, editData, { returnDocument: 'after', runValidators: true })

--- a/router/auth.js
+++ b/router/auth.js
@@ -14,8 +14,6 @@ router.post('/signup', authController.signup)
 router.post('/login', authController.login)
 // 登出
 router.post('/logout', authController.logout)
-// 修改密碼
-router.patch('/reset-password', isAuth, authController.resetPassword)
 // 驗證token
 router.get('/check', authController.checkToken)
 

--- a/router/user.js
+++ b/router/user.js
@@ -14,6 +14,10 @@ router
   .patch(isAuth, userController.updateCurrentUserInfo) // 修改個人資訊
 
 router
+  .route('/reset-password')
+  .patch(isAuth, userController.resetPassword)// 修改密碼
+
+router
   .route('/:user_id')
   .get(isAuth, userController.getUserInfo) // 取得個人資訊
   .post(isAuth, userController.createUserInfo) // 新增個人資訊


### PR DESCRIPTION
### fix: 使用者修改密碼從 auth 模組 轉移到 users 模組
~原API：[PATCH]`/api/auth/reset-password`~
- API：[PATCH]`/api/users/reset-password`
- body：
```json
{
    "password":"新密碼",
    "confirmPassword":"再次確認新密碼"
}
```
因為會用到一些 `controller/auth.js` 內的方法，所以有對一些方法 export 

---

(次要)
fix: 修改時，沒提供 name 不擋(undefined)
API：[PATCH] `/api/users/current-userinfo`
API：[PATCH] `/api/users/{{user_id}}`
使用者修改個人資訊
加了判斷 `xxx !== undefined`，xxx是avatar, gender, name